### PR TITLE
Update spec file to version 0.14.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git clone https://github.com/mlazarov/syncthing-centos.git rpmbuild/
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros
 cd ~/rpmbuild/SOURCES/
-wget https://github.com/syncthing/syncthing/releases/download/v0.14.7/syncthing-linux-amd64-v0.14.7.tar.gz
+spectool -g ../SPECS/syncthing.spec
 cd ~/rpmbuild/SPECS/
 rpmbuild -bb syncthing.spec
 ```

--- a/SPECS/syncthing.spec
+++ b/SPECS/syncthing.spec
@@ -1,5 +1,5 @@
 Name:		syncthing
-Version:	0.14.7
+Version:	0.14.23
 Release:	0%{?dist}
 Summary:	Open, trustworthy and decentralized sync
 # Set to amd64 or 386
@@ -8,7 +8,7 @@ Summary:	Open, trustworthy and decentralized sync
 Group:		Applications/System
 License:	MPLv2
 URL:		https://github.com/syncthing/syncthing
-Source0:	https://github.com/syncthing/syncthing/releases/download/v${version}/syncthing-linux-%{arch}-v%{version}.tar.gz
+Source0:	https://github.com/syncthing/syncthing/releases/download/v%{version}/syncthing-linux-%{arch}-v%{version}.tar.gz
 
 Requires:	policycoreutils-python
 
@@ -29,6 +29,7 @@ cp syncthing %{buildroot}/usr/bin/
 
 mkdir -p %{buildroot}/etc/systemd/system/
 cp etc/linux-systemd/system/syncthing\@.service  %{buildroot}/etc/systemd/system/
+cp etc/linux-systemd/system/syncthing-resume.service  %{buildroot}/etc/systemd/system/
 mkdir -p %{buildroot}/etc/systemd/user/
 cp etc/linux-systemd/user/syncthing.service %{buildroot}/etc/systemd/user/
 
@@ -37,9 +38,13 @@ cp etc/linux-systemd/user/syncthing.service %{buildroot}/etc/systemd/user/
 %defattr(-,root,root)
 /usr/bin/syncthing
 /etc/systemd/system/syncthing@.service
+/etc/systemd/system/syncthing-resume.service
 /etc/systemd/user/syncthing.service
 
 %changelog
+* Thu Feb  9 2017 Pierre-Alain TORET <pierre-alain.toret@protonmail.com>
+- Bump synthing version 0.14.7 -> 0.14.23
+
 * Thu Sep 22 2016 Logan Owen <logan@s1network.com>
 - Bump synthing version 0.13.1 -> 0.14.7
 


### PR DESCRIPTION
I also added an easier way of retrieving the source tarball, so the README.md doesn't have to be updated at every new release.